### PR TITLE
resolve symbolic links when processing ENVs

### DIFF
--- a/src/from/envs.ts
+++ b/src/from/envs.ts
@@ -1,20 +1,46 @@
+import * as fs from "fs/promises";
 import * as path from "path";
+import * as logger from "../logger";
+
+import { JAVA_FILENAME } from "..";
 import { expandTilde, looksLikeJavaHome } from "../utils";
 
-export function candidatesFromPath(): string[] {
+export async function candidatesFromPath(): Promise<string[]> {
     const ret = [];
     if (process.env.PATH) {
-        const jdkBinFolderFromPath = process.env.PATH.split(path.delimiter).filter(looksLikeJavaHome);
-        const homeDirs = jdkBinFolderFromPath.map(p => path.dirname(p));
+        const jdkBinFolderFromPath = process.env.PATH.split(path.delimiter).filter(looksLikeJavaHome)
+            .map(expandTilde); // '~' can occur in envs in Unix-like systems
+
+        /**
+         * Fix for https://github.com/Eskibear/node-jdk-utils/issues/2
+         * Homebrew creates symbolic links for each binary instead of folder.
+         */
+        const homeDirs = await Promise.all(jdkBinFolderFromPath.map(p => getRealHome(path.join(p, JAVA_FILENAME))));
         ret.push(...homeDirs);
     }
-    return ret.map(expandTilde); // '~' can occur in envs in Unix-like systems
+    return ret.filter(Boolean) as string[]; 
 }
 
-export function candidatesFromSpecificEnv(envkey: string): string | undefined {
+export async function candidatesFromSpecificEnv(envkey: string): Promise<string | undefined> {
     if (process.env[envkey]) {
         const rmSlash = process.env[envkey]!.replace(/[\\\/]$/, ""); // remove trailing slash if exists
-        return expandTilde(rmSlash);
+        return getRealHome(path.join(rmSlash, "bin", JAVA_FILENAME));
     }
     return undefined;
+}
+
+/**
+ * Get real Java Home directory, with symbolic links resolved.
+ * @param javaBinaryPathLike e.g. some-path/bin/java
+ * @returns some-path
+ */
+async function getRealHome(javaBinaryPathLike: string): Promise<string | undefined> {
+    const javaBinaryPath = expandTilde(javaBinaryPathLike);
+    try {
+        const rp = await fs.realpath(javaBinaryPath);
+        return path.dirname(path.dirname(rp));
+    } catch (error) {
+        logger.log(error);
+    }
+    return undefined; 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,19 +106,19 @@ export async function findRuntimes(options?: IOptions): Promise<IJavaRuntime[]> 
     }
 
     // from env: JDK_HOME
-    const fromJdkHome = envs.candidatesFromSpecificEnv("JDK_HOME");
+    const fromJdkHome = await envs.candidatesFromSpecificEnv("JDK_HOME");
     if (fromJdkHome) {
         updateCandidates([fromJdkHome], (r) => ({ ...r, isJdkHomeEnv: true }));
     }
 
     // from env: JAVA_HOME
-    const fromJavaHome = envs.candidatesFromSpecificEnv("JAVA_HOME");
+    const fromJavaHome = await envs.candidatesFromSpecificEnv("JAVA_HOME");
     if (fromJavaHome) {
         updateCandidates([fromJavaHome], (r) => ({ ...r, isJavaHomeEnv: true }));
     }
 
     // from env: PATH
-    const fromPath = envs.candidatesFromPath();
+    const fromPath = await envs.candidatesFromPath();
     updateCandidates(fromPath, (r) => ({ ...r, isInPathEnv: true }));
 
     // jEnv
@@ -191,14 +191,14 @@ export async function getRuntime(homedir: string, options?: IOptions): Promise<I
         if (jbList.includes(homedir)) {
             runtime.isFromJabba = true;
         }
-        const pList = envs.candidatesFromPath();
+        const pList = await envs.candidatesFromPath();
         if (pList.includes(homedir)) {
             runtime.isInPathEnv = true;
         }
-        if (envs.candidatesFromSpecificEnv("JAVA_HOME") === homedir) {
+        if (await envs.candidatesFromSpecificEnv("JAVA_HOME") === homedir) {
             runtime.isJavaHomeEnv = true;
         }
-        if (envs.candidatesFromSpecificEnv("JDK_HOME") === homedir) {
+        if (await envs.candidatesFromSpecificEnv("JDK_HOME") === homedir) {
             runtime.isJdkHomeEnv = true;
         }
     }


### PR DESCRIPTION
See #2

It now resolves the realpath of symbolic links, below is an example of openjdk installed via homebrew.

```
$ export PATH="/usr/local/opt/openjdk/bin:$PATH"
$ which java
/usr/local/opt/openjdk/bin/java
```

```jsonc
...
  {
    homedir: '/usr/local/Cellar/openjdk/17.0.1_1/libexec/openjdk.jdk/Contents/Home',
    isInPathEnv: true,
    hasJavac: true,
    version: { java_version: '17.0.1', major: 17 }
  }
...
```