### PR TITLE
macOS: support to detect from Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Covering:
 * SDKMAN installation location.
 * jabba installation location, i.e. `~/.jabba/jdk`
 * Links specified in jEnv.
+* Homebrew installation, i.e. symbolic links under `/usr/local/opt`. (macOS only)
 * Platform-specific conventional installation location:
   * Linux: `/usr/lib/jvm`
   * macOS: `/Library/Java/JavaVirtualMachines`, `~/Library/Java/JavaVirtualMachines`, output of `java_home -V`.

--- a/src/from/envs.ts
+++ b/src/from/envs.ts
@@ -1,9 +1,5 @@
-import * as fs from "fs/promises";
 import * as path from "path";
-import * as logger from "../logger";
-
-import { JAVA_FILENAME } from "..";
-import { expandTilde, looksLikeJavaHome } from "../utils";
+import { expandTilde, getRealHome, looksLikeJavaHome } from "../utils";
 
 export async function candidatesFromPath(): Promise<string[]> {
     const ret = [];
@@ -15,32 +11,16 @@ export async function candidatesFromPath(): Promise<string[]> {
          * Fix for https://github.com/Eskibear/node-jdk-utils/issues/2
          * Homebrew creates symbolic links for each binary instead of folder.
          */
-        const homeDirs = await Promise.all(jdkBinFolderFromPath.map(p => getRealHome(path.join(p, JAVA_FILENAME))));
+        const homeDirs = await Promise.all(jdkBinFolderFromPath.map(p => getRealHome(path.dirname(p))));
         ret.push(...homeDirs);
     }
-    return ret.filter(Boolean) as string[]; 
+    return ret.filter(Boolean) as string[];
 }
 
 export async function candidatesFromSpecificEnv(envkey: string): Promise<string | undefined> {
     if (process.env[envkey]) {
         const rmSlash = process.env[envkey]!.replace(/[\\\/]$/, ""); // remove trailing slash if exists
-        return getRealHome(path.join(rmSlash, "bin", JAVA_FILENAME));
+        return getRealHome(rmSlash);
     }
     return undefined;
-}
-
-/**
- * Get real Java Home directory, with symbolic links resolved.
- * @param javaBinaryPathLike e.g. some-path/bin/java
- * @returns some-path
- */
-async function getRealHome(javaBinaryPathLike: string): Promise<string | undefined> {
-    const javaBinaryPath = expandTilde(javaBinaryPathLike);
-    try {
-        const rp = await fs.realpath(javaBinaryPath);
-        return path.dirname(path.dirname(rp));
-    } catch (error) {
-        logger.log(error);
-    }
-    return undefined; 
 }

--- a/src/from/homebrew.ts
+++ b/src/from/homebrew.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+import { log } from "../logger";
+import { deDup, getRealHome, looksLikeJavaHome } from "../utils";
+
+/*
+$ ls -l /usr/local/opt
+openjdk -> ../Cellar/openjdk/15.0.1
+openjdk@11 -> ../Cellar/openjdk@11/11.0.12
+openjdk@15 -> ../Cellar/openjdk/15.0.1
+
+$ ls -l /usr/local/opt/openjdk/bin/java
+/usr/local/opt/openjdk/bin/java -> ../libexec/openjdk.jdk/Contents/Home/bin/java
+
+# Real path is:
+# /usr/local/Cellar/openjdk/15.0.1/libexec/openjdk.jdk/Contents/Home/bin/java
+
+*/
+const HOMEBREW_DIR = "/usr/local/opt";
+export async function candidates(): Promise<string[]> {
+    const ret = [];
+    try {
+        const files = await fs.promises.readdir(HOMEBREW_DIR, { withFileTypes: true });
+        const homeDirLinks = files.filter(file => file.isSymbolicLink() && looksLikeJavaHome(file.name)).map(file => path.join(HOMEBREW_DIR, file.name));
+
+        const actualHomeDirs = await Promise.all(deDup(homeDirLinks).map(file => getRealHome(file)))
+        ret.push(...actualHomeDirs);
+    } catch (error) {
+        log(error);
+    }
+    return ret.filter(Boolean) as string[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as envs from "./from/envs";
+import * as homebrew from "./from/homebrew";
 import * as jabba from "./from/jabba";
 import * as jenv from "./from/jenv";
 import * as linux from "./from/linux";
@@ -9,14 +10,9 @@ import * as macOS from "./from/macOS";
 import * as sdkman from "./from/sdkman";
 import * as windows from "./from/windows";
 import * as logger from "./logger";
-import { deDup } from "./utils";
+import { deDup, isLinux, isMac, isWindows, JAVAC_FILENAME, JAVA_FILENAME } from "./utils";
 
-const isWindows: boolean = process.platform.indexOf("win") === 0;
-const isMac: boolean = process.platform.indexOf("darwin") === 0;
-const isLinux: boolean = process.platform.indexOf("linux") === 0;
-
-export const JAVA_FILENAME = isWindows ? "java.exe" : "java";
-export const JAVAC_FILENAME = isWindows ? "javac.exe" : "javac";
+export { JAVAC_FILENAME, JAVA_FILENAME } from "./utils";
 
 export interface IOptions {
     /**
@@ -44,7 +40,7 @@ export interface IJavaRuntime {
      */
     homedir: string;
     /**
-     * Version information. 
+     * Version information.
      */
     version?: IJavaVersion;
     /**
@@ -74,9 +70,9 @@ export interface IJavaRuntime {
 
 /**
  * Find Java runtime from all possible locations on your machine.
- * 
+ *
  * @param options advanced options
- * @returns 
+ * @returns
  */
 export async function findRuntimes(options?: IOptions): Promise<IJavaRuntime[]> {
     const store = new RuntimeStore();
@@ -100,6 +96,7 @@ export async function findRuntimes(options?: IOptions): Promise<IJavaRuntime[]> 
     }
     if (isMac) {
         updateCandidates(await macOS.candidates());
+        updateCandidates(await homebrew.candidates()); // Homebrew
     }
     if (isWindows) {
         updateCandidates(await windows.candidates());
@@ -159,10 +156,10 @@ export async function findRuntimes(options?: IOptions): Promise<IJavaRuntime[]> 
 
 /**
  * Verify if given directory contains a valid Java runtime, and provide details if it is.
- * 
+ *
  * @param homedir home directory of a Java runtime
- * @param options 
- * @returns 
+ * @param options
+ * @returns
  */
 export async function getRuntime(homedir: string, options?: IOptions): Promise<IJavaRuntime | undefined> {
     let runtime: IJavaRuntime = { homedir };
@@ -207,7 +204,7 @@ export async function getRuntime(homedir: string, options?: IOptions): Promise<I
 
 /**
  * A utility to list all sources where given Java runtime is found.
- * 
+ *
  * @param r given IJavaRuntime
  * @returns list of sources where given runtime is found.
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,14 @@
-import { join } from "path";
+import * as fs from "fs";
 import { homedir } from "os";
+import { dirname, join } from "path";
+import * as logger from "./logger";
+
+export const isWindows: boolean = process.platform.indexOf("win") === 0;
+export const isMac: boolean = process.platform.indexOf("darwin") === 0;
+export const isLinux: boolean = process.platform.indexOf("linux") === 0;
+
+export const JAVA_FILENAME = isWindows ? "java.exe" : "java";
+export const JAVAC_FILENAME = isWindows ? "javac.exe" : "javac";
 
 export function looksLikeJavaHome(dir: string) {
     const lower = dir.toLocaleLowerCase();
@@ -17,4 +26,21 @@ export function expandTilde(filepath: string) {
 
         return filepath;
     }
+}
+
+/**
+ * Get real Java Home directory, deducted from real path of 'bin/java', with symbolic links resolved.
+ * Mainly for Homebrew.
+ * @param javaHomePathLike e.g. some-path supposed to have 'bin/java' under it.
+ * @returns a valid java home
+ */
+export async function getRealHome(javaHomePathLike: string): Promise<string | undefined> {
+    const javaBinaryPath = expandTilde(join(javaHomePathLike, "bin", JAVA_FILENAME));
+    try {
+        const rp = await fs.promises.realpath(javaBinaryPath);
+        return dirname(dirname(rp));
+    } catch (error) {
+        logger.log(error);
+    }
+    return undefined;
 }


### PR DESCRIPTION
to fix #2 

smoke test:

```
$> ls -l /usr/local/opt/ | grep jdk
lrwxr-xr-x  1 sechs  admin  24 Dec 10  2020 java -> ../Cellar/openjdk/15.0.1
lrwxr-xr-x  1 sechs  admin  28 Dec 20 21:31 java11 -> ../Cellar/openjdk@11/11.0.12
lrwxr-xr-x  1 sechs  admin  24 Dec 10  2020 openjdk -> ../Cellar/openjdk/15.0.1
lrwxr-xr-x  1 sechs  admin  28 Dec 20 21:31 openjdk@11 -> ../Cellar/openjdk@11/11.0.12
lrwxr-xr-x  1 sechs  admin  24 Dec 10  2020 openjdk@15 -> ../Cellar/openjdk/15.0.1

$> export PATH=/usr/local/opt/openjdk/bin:$PATH

findRuntimes:
...
  {
    homedir: '/usr/local/Cellar/openjdk/15.0.1/libexec/openjdk.jdk/Contents/Home',
    isInPathEnv: true,
    hasJavac: true,
    version: { java_version: '15.0.1', major: 15 }
  },
  {
    homedir: '/usr/local/Cellar/openjdk@11/11.0.12/libexec/openjdk.jdk/Contents/Home',
    hasJavac: true,
    version: { java_version: '11.0.12', major: 11 }
  }
...
```