### PR TITLE
Initial support for asdf-vm

### DIFF
--- a/src/from/asdf.ts
+++ b/src/from/asdf.ts
@@ -3,7 +3,7 @@ import * as os from "os";
 import * as path from "path";
 import { log } from "../logger";
 
-const ASDF_DIR = path.join(os.homedir(), ".asdf");
+const ASDF_DIR = process.env.ASDF_DIR ?? path.join(os.homedir(), ".asdf");
 const JDK_BASE_DIR = path.join(ASDF_DIR, "installs", "java");
 
 export async function candidates(): Promise<string[]> {

--- a/src/from/asdf.ts
+++ b/src/from/asdf.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { log } from "../logger";
+
+const ASDF_DIR = path.join(os.homedir(), ".asdf");
+const JDK_BASE_DIR = path.join(ASDF_DIR, "installs", "java");
+
+export async function candidates(): Promise<string[]> {
+    const ret = [];
+    try {
+        const files = await fs.promises.readdir(JDK_BASE_DIR, { withFileTypes: true });
+        const homedirs = files.filter(file => file.isDirectory()).map(file => path.join(JDK_BASE_DIR, file.name));
+        ret.push(...homedirs);
+    } catch (error) {
+        log(error);
+    }
+    return ret;
+}


### PR DESCRIPTION
Hi @Eskibear, thanks a lot for this package. It solves a real problem for many.

I recently changed from a Mac to a Windows developing workflow. WSL2 is handy when working on Windows. But my go to editor VSCode doesn't seem to support asdf-vm installed JDKs. Searching for it on google lead me to redhat-developer/vscode-java#2025

I went ahead and pushed some changes to that should fix #6.

I reckon that this approach is a little simplistic since asdf-vm can be installed on other folders. But I'll work on improving this while we talk about this PR.

Let me know if you need me to do any other change.

Thanks again!