### PR TITLE
Use asdf data directory instead of asdf install directory

### DIFF
--- a/src/from/asdf.ts
+++ b/src/from/asdf.ts
@@ -3,8 +3,8 @@ import * as os from "os";
 import * as path from "path";
 import { log } from "../logger";
 
-const ASDF_DIR = process.env.ASDF_DIR ?? path.join(os.homedir(), ".asdf");
-const JDK_BASE_DIR = path.join(ASDF_DIR, "installs", "java");
+const ASDF_DATA_DIR = process.env.ASDF_DATA_DIR ?? path.join(os.homedir(), ".asdf");
+const JDK_BASE_DIR = path.join(ASDF_DATA_DIR, "installs", "java");
 
 export async function candidates(): Promise<string[]> {
     const ret = [];


### PR DESCRIPTION
This pull request fixes an issue where Java runtimes from non-git asdf installations would not be discovered.

Depending on the asdf installation method, the `ASDF_DIR` environment variable sometimes points to a directory that does not contain asdf installs. [`ASDF_DIR` represents the location of asdf itself, rather than the location of asdf installs.](https://asdf-vm.com/manage/configuration.html#environment-variables) For example, `ASDF_DIR` is set to `/opt/homebrew/opt/asdf/libexec/` on my machine because asdf is installed through Homebrew.

Instead, the `ASDF_DATA_DIR` environment variable can be used, enabling the discovery of Java runtimes from non-git asdf installations.