### PR TITLE
Supported Zulu

### DIFF
--- a/src/from/windows.ts
+++ b/src/from/windows.ts
@@ -18,6 +18,7 @@ const POPULAR_DISTRIBUTIONS = [
     "Amazon Corretto",
     "Microsoft", // Microsoft OpenJDK
     path.join("SapMachine", "JDK"), // SAP Machine
+    "Zulu", // Azul OpenJDK
 ];
 
 export async function candidates(): Promise<string[]> {


### PR DESCRIPTION
Supported https://www.azul.com/downloads/?package=jdk#zulu on Windows. Location is `C:\Program Files\Zulu\zulu-11`