### PR TITLE
Exclude the macOS preserved '/usr' from java home list

### DIFF
--- a/src/from/envs.ts
+++ b/src/from/envs.ts
@@ -1,7 +1,11 @@
 import * as fs from "fs";
 import * as path from "path";
-import { expandTilde, getRealHome, looksLikeJavaHome, JAVA_FILENAME } from "../utils";
+import { expandTilde, getRealHome, looksLikeJavaHome, JAVA_FILENAME, isMac } from "../utils";
 
+const EXCLUSIONS_ON_MAC: Set<string> = new Set([
+    "/usr",
+    "/usr/"
+]);
 export async function candidatesFromPath(): Promise<string[]> {
     const ret = [];
     if (process.env.PATH) {
@@ -13,7 +17,13 @@ export async function candidatesFromPath(): Promise<string[]> {
          * Fix for https://github.com/Eskibear/node-jdk-utils/issues/2
          * Homebrew creates symbolic links for each binary instead of folder.
          */
-        const homeDirs = await Promise.all(jdkBinFolderFromPath.map(p => getRealHome(path.dirname(p))));
+        const homeDirs = (await Promise.all(jdkBinFolderFromPath.map(p => getRealHome(path.dirname(p))))).filter(homeDir => {
+            /**
+             * Fix for https://github.com/Eskibear/node-jdk-utils/issues/15
+             * /usr/bin/java is a preserved shortcut program on macOS, which is not a real java home.
+             */
+            return homeDir && (!isMac || !EXCLUSIONS_ON_MAC.has(homeDir));
+        });
         ret.push(...homeDirs);
     }
     return ret.filter(Boolean) as string[];

--- a/src/from/envs.ts
+++ b/src/from/envs.ts
@@ -22,7 +22,7 @@ export async function candidatesFromPath(): Promise<string[]> {
              * Fix for https://github.com/Eskibear/node-jdk-utils/issues/15
              * /usr/bin/java is a preserved shortcut program on macOS, which is not a real java home.
              */
-            return homeDir && (!isMac || !EXCLUSIONS_ON_MAC.has(homeDir));
+            return homeDir && !(isMac && EXCLUSIONS_ON_MAC.has(homeDir));
         });
         ret.push(...homeDirs);
     }


### PR DESCRIPTION
Fixes #15