### PR TITLE
Add support for mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Covering:
 * jabba installation location, i.e. `~/.jabba/jdk`
 * [JBang](https://jbang.dev/) installation location, i.e. `~/.jbang/cache/jdks`
 * ASDF installation location.
-* mise installation location.
+* [mise](https://mise.jdx.dev/lang/java.html) installation location, i.e. `~/.local/share/mise/installs/java`.
 * JDK installations managed by [Gradle](https://docs.gradle.org/8.1/userguide/toolchains.html), e.g. `~/.gradle/jdk`
 * Links specified in jEnv.
 * Homebrew installation:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Covering:
 * jabba installation location, i.e. `~/.jabba/jdk`
 * [JBang](https://jbang.dev/) installation location, i.e. `~/.jbang/cache/jdks`
 * ASDF installation location.
+* mise installation location.
 * JDK installations managed by [Gradle](https://docs.gradle.org/8.1/userguide/toolchains.html), e.g. `~/.gradle/jdk`
 * Links specified in jEnv.
 * Homebrew installation:

--- a/src/from/mise.ts
+++ b/src/from/mise.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { log } from "../logger";
+
+const MISE_DATA_DIR = process.env.MISE_DATA_DIR ?? path.join(os.homedir(), ".local", "share", "mise");
+const JDK_BASE_DIR = path.join(MISE_DATA_DIR, "installs", "java");
+
+export async function candidates(): Promise<string[]> {
+    const ret = [];
+    try {
+        const files = await fs.promises.readdir(JDK_BASE_DIR, { withFileTypes: true });
+        const homedirs = files.filter(file => file.isDirectory()).map(file => path.join(JDK_BASE_DIR, file.name));
+        ret.push(...homedirs);
+    } catch (error) {
+        log(error);
+    }
+    return ret;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import * as jabba from "./from/jabba";
 import * as jenv from "./from/jenv";
 import * as linux from "./from/linux";
 import * as macOS from "./from/macOS";
+import * as mise from "./from/mise";
 import * as sdkman from "./from/sdkman";
 import * as windows from "./from/windows";
 import * as logger from "./logger";
@@ -64,6 +65,10 @@ export interface IOptions {
          */
         asdf?: boolean;
         /**
+         * from mise
+         */
+        mise?: boolean;
+        /**
          * from Gradle locations
          */
         gradle?: boolean;
@@ -113,6 +118,7 @@ export interface IJavaRuntime {
     isFromJabba?: boolean;
     isFromJBang?: boolean;
     isFromASDF?: boolean;
+    isFromMise?: boolean;
     isFromGradle?: boolean;
 }
 
@@ -199,6 +205,12 @@ export async function findRuntimes(options?: IOptions): Promise<IJavaRuntime[]> 
         updateCandidates(fromASDF, (r) => ({ ...r, isFromASDF: true }));
     }
 
+    // mise
+    if (!options?.skipFrom?.mise) {
+        const fromMise = await mise.candidates();
+        updateCandidates(fromMise, (r) => ({ ...r, isFromMise: true }));
+    }
+
     // Gradle
     if (!options?.skipFrom?.gradle) {
         const fromGradle = await gradle.candidates();
@@ -267,6 +279,10 @@ export async function getRuntime(homedir: string, options?: IOptions): Promise<I
         if (aList.includes(homedir)) {
             runtime.isFromASDF = true;
         }
+        const mList = await mise.candidates();
+        if (mList.includes(homedir)) {
+            runtime.isFromMise = true;
+        }
         const jList = await jenv.candidates();
         if (jList.includes(homedir)) {
             runtime.isFromJENV = true;
@@ -324,6 +340,9 @@ export function getSources(r: IJavaRuntime): string[] {
     }
     if (r.isFromASDF) {
         sources.push("asdf");
+    }
+    if (r.isFromMise) {
+        sources.push("mise");
     }
     if (r.isFromGradle) {
         sources.push("Gradle");


### PR DESCRIPTION
Before:

```bash
ylecuyer@hawk node-jdk-utils % node bin/cli.js
Listing JDKs: 197.53ms
Found:  1
[
  {
    homedir: '/opt/homebrew/Cellar/openjdk@21/21.0.9/libexec/openjdk.jdk/Contents/Home',
    hasJavac: true,
    version: { java_version: '21.0.9', major: 21 }
  }
]
```

After:

```bash
ylecuyer@hawk node-jdk-utils % node bin/cli.js
Listing JDKs: 47.111ms
Found:  3
[
  {
    homedir: '/opt/homebrew/Cellar/openjdk@21/21.0.9/libexec/openjdk.jdk/Contents/Home',
    hasJavac: true,
    version: { java_version: '21.0.9', major: 21 }
  },
  {
    homedir: '/Users/ylecuyer/.local/share/mise/installs/java/21.0.2',
    isFromMise: true,
    hasJavac: true,
    version: { java_version: '21.0.2', major: 21 }
  },
  {
    homedir: '/Users/ylecuyer/.local/share/mise/installs/java/corretto-17.0.16.8.1',
    isFromMise: true,
    hasJavac: true,
    version: { java_version: '17.0.16', major: 17 }
  }
]
```
