### PR TITLE
Detect SDKMAN installed via Homebrew (#22)

### DIFF
--- a/src/from/sdkman.ts
+++ b/src/from/sdkman.ts
@@ -2,18 +2,34 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { log } from "../logger";
+import { isArm, isLinux, isMac } from "../utils";
 
 const SDKMAN_DIR = process.env.SDKMAN_DIR ?? path.join(os.homedir(), ".sdkman");
-const JDK_BASE_DIR = path.join(SDKMAN_DIR, "candidates", "java");
+
+// Homebrew-installed SDKMAN locations (sdkman-cli formula).
+// See: https://formulae.brew.sh/formula/sdkman-cli
+const HOMEBREW_SDKMAN_APPLE_SILLICON = "/opt/homebrew/opt/sdkman-cli/libexec";
+const HOMEBREW_SDKMAN_INTEL = "/usr/local/opt/sdkman-cli/libexec";
+const HOMEBREW_SDKMAN_LINUX = "/home/linuxbrew/.linuxbrew/opt/sdkman-cli/libexec";
 
 export async function candidates(): Promise<string[]> {
-    const ret = [];
-    try {
-        const files = await fs.promises.readdir(JDK_BASE_DIR, { withFileTypes: true });
-        const homedirs = files.filter(file => file.isDirectory()).map(file => path.join(JDK_BASE_DIR, file.name));
-        ret.push(...homedirs);
-    } catch (error) {
-        log(error);
+    const sdkmanDirs = [SDKMAN_DIR];
+    if (isMac) {
+        sdkmanDirs.push(isArm ? HOMEBREW_SDKMAN_APPLE_SILLICON : HOMEBREW_SDKMAN_INTEL);
+    } else if (isLinux) {
+        sdkmanDirs.push(HOMEBREW_SDKMAN_LINUX);
+    }
+
+    const ret: string[] = [];
+    for (const sdkmanDir of sdkmanDirs) {
+        const jdkBaseDir = path.join(sdkmanDir, "candidates", "java");
+        try {
+            const files = await fs.promises.readdir(jdkBaseDir, { withFileTypes: true });
+            const homedirs = files.filter(file => file.isDirectory()).map(file => path.join(jdkBaseDir, file.name));
+            ret.push(...homedirs);
+        } catch (error) {
+            log(error);
+        }
     }
     return ret;
 }


### PR DESCRIPTION
Closes #22.

When SDKMAN is installed through Homebrew (`brew install sdkman-cli`), candidates live under the formula''s `libexec/candidates/java` instead of `~/.sdkman/candidates/java`. The `SDKMAN_DIR` env var is only set by the init script, so GUI-launched processes (e.g. VS Code from Spotlight on macOS) don''t inherit it and miss these JDKs.

### Change

`src/from/sdkman.ts` now scans Homebrew prefixes in addition to `SDKMAN_DIR`:

| Platform | Path |
| --- | --- |
| macOS Apple Silicon | `/opt/homebrew/opt/sdkman-cli/libexec` |
| macOS Intel | `/usr/local/opt/sdkman-cli/libexec` |
| Linuxbrew | `/home/linuxbrew/.linuxbrew/opt/sdkman-cli/libexec` |

Same platform-aware approach as `src/from/homebrew.ts`. Existing `~/.sdkman` / `SDKMAN_DIR` behavior is preserved. No new deps. No API changes.

### Verification
- `npm test` passes locally (7 passing).