### PR TITLE
Support additionalLocations option for custom JDK search paths (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Covering:
 
 Note: If you want to skip scanning a certain source for better performance, you can specify `skipFrom` options when calling the API.
 
+If you want to extend coverage without waiting for a new release, pass `additionalLocations` when calling the API. Each entry is a **parent folder** of possible Java Homes (not a Java Home itself); the lookup is shallow (direct subdirectories only).
+
+```ts
+import { findRuntimes } from "jdk-utils";
+await findRuntimes({ additionalLocations: ["/opt/my-jdks"] });
+```
+
 #### CLI
 
 Below command lists all detected JDKs with details.

--- a/src/from/custom.ts
+++ b/src/from/custom.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+import { log } from "../logger";
+
+/**
+ * List candidate Java homes under the given parent folders.
+ *
+ * Each entry is treated as a parent folder of possible Java Homes (not a Java
+ * Home itself). Lookup is shallow: only direct subdirectories are returned.
+ */
+export async function candidates(parentDirs: string[]): Promise<string[]> {
+    const ret: string[] = [];
+    for (const parent of parentDirs) {
+        try {
+            const files = await fs.promises.readdir(parent, { withFileTypes: true });
+            const homedirs = files.filter(file => file.isDirectory()).map(file => path.join(parent, file.name));
+            ret.push(...homedirs);
+        } catch (error) {
+            log(error);
+        }
+    }
+    return ret;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as jbang from "./from/jbang";
 import * as asdf from "./from/asdf";
+import * as custom from "./from/custom";
 import * as envs from "./from/envs";
 import * as gradle from "./from/gradle";
 import * as homebrew from "./from/homebrew";
@@ -31,6 +32,16 @@ export interface IOptions {
      * whether to include tags for detailed information
      */
     withTags?: boolean;
+
+    /**
+     * Additional parent folders to scan for Java Homes.
+     *
+     * Each entry is treated as a parent folder of possible Java Homes (not a
+     * Java Home itself). Lookup is shallow: only direct subdirectories are
+     * considered. Useful when consumers want to extend coverage without
+     * waiting for a new release of this library.
+     */
+    additionalLocations?: string[];
 
     /**
      * whether to skip resolving from a specific source
@@ -216,7 +227,13 @@ export async function findRuntimes(options?: IOptions): Promise<IJavaRuntime[]> 
         const fromGradle = await gradle.candidates();
         updateCandidates(fromGradle, (r) => ({ ...r, isFromGradle: true }));
     }
-    
+
+    // user-supplied additional parent folders
+    if (options?.additionalLocations?.length) {
+        const fromCustom = await custom.candidates(options.additionalLocations);
+        updateCandidates(fromCustom);
+    }
+
     // dedup and construct runtimes
     let runtimes: IJavaRuntime[] = options?.withTags ? store.allRuntimes()
         : deDup(candidates).map((homedir) => ({ homedir }));

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,8 @@
 'use strict'
 const expect = require("chai").expect;
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 describe("test this module", () => {
     const utils = require("../dist/index");
@@ -60,5 +63,21 @@ describe("test this module", () => {
         const jdks = await utils.findRuntimes({ withTags: true, withVersion: true, checkJavac: true });
         console.timeEnd(label);
         jdks.forEach(jdk => console.log(jdk.homedir, utils.getSources(jdk)));
+    });
+
+    it("should pick up JDKs from additionalLocations", async () => {
+        const isWindows = process.platform.indexOf("win") === 0;
+        const javaBinName = isWindows ? "java.exe" : "java";
+        const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "jdk-utils-test-"));
+        const fakeHome = path.join(tempRoot, "fake-jdk-21");
+        await fs.promises.mkdir(path.join(fakeHome, "bin"), { recursive: true });
+        await fs.promises.writeFile(path.join(fakeHome, "bin", javaBinName), "");
+        try {
+            const jdks = await utils.findRuntimes({ additionalLocations: [tempRoot] });
+            const homedirs = jdks.map(j => j.homedir);
+            expect(homedirs).to.include(fakeHome);
+        } finally {
+            await fs.promises.rm(tempRoot, { recursive: true, force: true });
+        }
     });
 });


### PR DESCRIPTION
Closes #19.

Implements the design [discussed by @Eskibear in the issue](https://github.com/Eskibear/node-jdk-utils/issues/19#issuecomment-2401126045): `additionalLocations: string[]`, each entry is a **parent folder** of possible Java Homes (not a Java Home itself), no recursive traverse.

### API

```ts
import { findRuntimes } from "jdk-utils";
await findRuntimes({ additionalLocations: ["/opt/my-jdks"] });
```

For every entry, direct subdirectories are treated as candidate Java Homes and go through the same `bin/java` validation as every other source. Consumers (e.g. the redhat.java extension) can now extend coverage without waiting for a new release.

### Changes
- New module `src/from/custom.ts` (mirrors the shape of `sdkman.ts` / `mise.ts`).
- New `additionalLocations?: string[]` field on `IOptions`.
- `findRuntimes` calls `custom.candidates(options.additionalLocations)` when provided.
- README documents the option.
- New smoke test creates a fake JDK in a temp dir and asserts it''s picked up.

### Notes / open questions
- Did not add an `isFromAdditional` tag or a `getSources` entry. These paths are caller-supplied so attribution back to the caller seems awkward. Happy to add it if you''d prefer symmetry with the other sources.
- Did not wire it into `skipFrom` since it''s opt-in by passing the array.

### Verification
- `npm test` passes locally (8/8, including the new test).