### PR TITLE
Resolve real Java Home for SDKMAN candidates (#17)

### DIFF
--- a/src/from/sdkman.ts
+++ b/src/from/sdkman.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { log } from "../logger";
-import { isArm, isLinux, isMac } from "../utils";
+import { getRealHome, isArm, isLinux, isMac } from "../utils";
 
 const SDKMAN_DIR = process.env.SDKMAN_DIR ?? path.join(os.homedir(), ".sdkman");
 
@@ -26,7 +26,12 @@ export async function candidates(): Promise<string[]> {
         try {
             const files = await fs.promises.readdir(jdkBaseDir, { withFileTypes: true });
             const homedirs = files.filter(file => file.isDirectory()).map(file => path.join(jdkBaseDir, file.name));
-            ret.push(...homedirs);
+            // Resolve real Java Home by following bin/java. For some distributions (e.g. Zulu on macOS),
+            // bin/java is a symlink into a nested .../Contents/Home folder, and tools like the Gradle
+            // daemon reject the surface path as a mismatched JAVA_HOME. Falls back to the original path
+            // when bin/java cannot be resolved.
+            const resolved = await Promise.all(homedirs.map(async (h) => (await getRealHome(h)) ?? h));
+            ret.push(...resolved);
         } catch (error) {
             log(error);
         }


### PR DESCRIPTION
Closes #17. Stacked on top of #25 to keep both `sdkman.ts` changes coherent — base will auto-retarget to `main` once #25 merges.

### Background

For some distributions (e.g. Zulu on macOS), SDKMAN exposes the candidate as `<sdkman>/candidates/java/<version>` while `bin/java` is actually a symlink into a nested `<version>/…/Contents/Home/bin/java`. Tools that re-validate `JAVA_HOME`, most notably the Gradle daemon, reject the surface path as a context mismatch:

```
Wanted: …javaHome=/Users/x/.sdkman/candidates/java/8.0.372-zulu
Actual: …javaHome=/Users/x/.sdkman/candidates/java/8.0.372-zulu/zulu-8.jdk/Contents/Home
```

### Fix

Follow `bin/java` via the existing `getRealHome` helper, the same approach already used in `src/from/homebrew.ts`. The reported Java Home now matches what the JVM itself reports.

For distributions whose `bin/java` is a regular file (most non-Zulu distros), `realpath` returns the same path and the resolved home is identical to the original, so existing behavior is preserved. When `bin/java` cannot be resolved at all, we fall back to the original path so later validation can reject it as before.

### Verification
- `npm test` passes locally (7/7).
- No new test was added: SDKMAN_DIR is read at module load, so simulating a Zulu-style symlinked layout would require either spawning a subprocess or refactoring the module. The change reuses `getRealHome`, which is already exercised via `from/homebrew.ts`.